### PR TITLE
Allow repository deb url to overridden using node properties. 

### DIFF
--- a/recipes/gridftp-default.rb
+++ b/recipes/gridftp-default.rb
@@ -22,8 +22,13 @@
 ##
 ##~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-gp_domain = node[:topology][:domains][node[:domain_id]]
-gp_node   = gp_domain[:nodes][node[:node_id]]
+if node.has_key?(:topology)
+  gp_domain = node[:topology][:domains][node[:domain_id]]
+  gp_node   = gp_domain[:nodes][node[:node_id]]
+  public_ip = gp_node[:public_id]
+else
+  public_ip = nil
+end
 
 include_recipe "globus::gridftp-common"
 
@@ -33,7 +38,7 @@ template "/etc/xinetd.d/gsiftp" do
   owner "root"
   group "root"
   variables(
-    :public_ip => gp_node[:public_ip],
+    :public_ip => public_ip,
     :gc        => false
   )
   notifies :restart, "service[xinetd]"

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -42,9 +42,15 @@ case node.platform
     
 end
 
+if node.has_key?("globus") and node.globus.has_key?("repository_deb_url")
+  repo_url = node.globus.repository_deb_url
+else
+  repo_url = "http://www.globus.org/ftppub/gt5/5.1/5.1.1/installers/repo/globus-repository-#{distro_id}_0.0.1_all.deb"
+end
+
 remote_file "#{node[:scratch_dir]}/gt5_repository.deb" do
   action :create_if_missing 
-  source "http://www.globus.org/ftppub/gt5/5.1/5.1.1/installers/repo/globus-repository-#{distro_id}_0.0.1_all.deb"
+  source repo_url
   owner "root"
   group "root"    
   mode "0644"


### PR DESCRIPTION
I don't know if this is the best way to address this, but this logic is quite dated and this change seems to allow me to setup this repository on a modern Ubuntu distribution.